### PR TITLE
Add note about required Slack's full reset

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 - ??????
 - PROFIT!!!!!!
 
+Use `Help -> Troubleshoot -> Reset Slack` to have the theme fully applied. Since it is a main version change, the `Clear Cache and Restart` option didn't made the magic.
+
 ### For Slack < 4.0
 Find your Slack's application directory.
 


### PR DESCRIPTION
Add essential note (from here: https://github.com/leoandreotti/slack-dark-theme) about the need of performing full Slack reset after applying these steps. Without this reset the dark theme looks awfully (at least under Windows 10), most GUI elements are not readable and whole thing sucks.